### PR TITLE
Feature/multi path parquet json reader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-spark-connector",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-spark-connector",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "^1.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-spark-connector",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A TypeScript client for Apache Spark Connect. Build Spark logical plans entirely in TypeScript.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/engine/logicalPlan.ts
+++ b/src/engine/logicalPlan.ts
@@ -37,7 +37,7 @@ export type GroupBy = {
 };
 
 export type LogicalPlan =
-    | { type: "Relation"; format: string; path: string; options?: Record<string, string> }
+    | { type: "Relation"; format: string; path: string | string[]; options?: Record<string, string> }
     | { type: "Filter"; input: LogicalPlan; condition: Expression }
     | { type: "Project"; input: LogicalPlan; columns: Expression[] }
     | {

--- a/src/spark/dataframe.ts
+++ b/src/spark/dataframe.ts
@@ -54,7 +54,7 @@ export interface ExprAlg<E> {
 }
 
 export interface DFAlg<R, E, G = unknown> {
-    relation(format: string, path: string, options?: Record<string, string>): R;
+    relation(format: string, path: string | string[], options?: Record<string, string>): R;
 
     select(plan: R, columns: E[]): R;
 


### PR DESCRIPTION
**Descripción**  
Este PR agrega soporte para lectura de múltiples rutas en formatos Parquet y JSON dentro de `DataFrameReaderTF`. Ahora los métodos `.csv()`, `.json()` y `.parquet()` aceptan uno o varios paths, alineándose con el comportamiento esperado en entornos Spark reales.  

**Cambios principales**  
- Actualización de la firma de `relation` y `LogicalPlan` para permitir `string | string[]` en el parámetro `path`.  
- Modificación de `DataFrameReaderTF` para manejar correctamente `paths` múltiples y pasar el formato correspondiente a `make()`.  
- Refactorización interna para unificar la lógica de lectura multipath.  

**Beneficios**  
- Permite operaciones de lectura más flexibles y cercanas al API nativo de Spark.  
- Facilita casos de uso donde los datos están distribuidos en múltiples directorios o archivos.  

**Pruebas**  
- Se probaron casos con un solo path y con múltiples paths en formatos `parquet` y `json`.  
- Compatibilidad mantenida con el comportamiento previo para `csv()`.  
