### PR TITLE
feat(read): implementa describe() y summary() en ReadChainedDataFrame…

### DIFF
--- a/src/engine/compilerRead.ts
+++ b/src/engine/compilerRead.ts
@@ -155,18 +155,17 @@ export const ProtoDFAlg: DFAlg<ProtoRel, ProtoExpr, ProtoGroup> = {
             input,
             order: orders.map(o => {
                 // “desenvolvé” sortKey si vino de EX.sortKey(...)
-                const expr =
-                    o.expr && o.expr.sort_key_marker ? o.expr.sort_key_marker.input : o.expr;
+                const expr = o.expr && o.expr.sort_key_marker ? o.expr.sort_key_marker.input : o.expr;
                 return {
                     child: expr,
                     direction: toProtoSortDirection(o.direction), // "ASCENDING" | "DESCENDING"
+
                     // En tu compiler usabas boolean nulls_first; mantenemos ese contrato:
-                    nulls_first:
-                        o.nulls === "nullsFirst"
-                            ? true
-                            : o.nulls === "nullsLast"
-                                ? false
-                                : undefined,
+                    nulls_first: o.nulls === "nullsFirst"
+                        ? true
+                        : o.nulls === "nullsLast"
+                            ? false
+                            : undefined,
                 };
             }),
         },
@@ -241,6 +240,21 @@ export const ProtoDFAlg: DFAlg<ProtoRel, ProtoExpr, ProtoGroup> = {
                 },
             })),
         },
+    }),
+    describe: (plan, columns) => ({
+        project: {
+            plan,
+            expressions: columns,
+        },
+    }),
+    summary: (plan, metrics, columns) => ({
+        extension: {
+            value: {
+                input: plan,
+                metrics,
+                columns,
+            },
+        }
     }),
 };
 

--- a/src/engine/logicalPlan.ts
+++ b/src/engine/logicalPlan.ts
@@ -1,4 +1,4 @@
-import { GroupTypeInput, JoinTypeInput } from "./sparkConnectEnums";
+import {GroupTypeInput, JoinTypeInput} from "./sparkConnectEnums";
 import {FrameBoundary} from "./column";
 import {FrameType, SortOrder} from "../read/readDataframe";
 
@@ -24,19 +24,15 @@ export type LogicalPlan =
     | { type: "Relation"; format: string; path: string | string[]; options?: Record<string, string> }
     | { type: "Filter"; input: LogicalPlan; condition: Expression }
     | { type: "Project"; input: LogicalPlan; columns: Expression[] }
-    | {
-    type: "Aggregate";
-    input: GroupBy;
-    // ⬇⬇⬇ AQUÍ el cambio clave
-    aggregations: Record<string, Expression>;
-    groupType?: GroupTypeInput;
-}
+    | { type: "Aggregate";input: GroupBy;aggregations: Record<string, Expression>;groupType?: GroupTypeInput;}
     | { type: "GroupBy"; input: LogicalPlan; expressions: Expression[] }
     | { type: "Join"; left: LogicalPlan; right: LogicalPlan; on: Expression; joinType: JoinTypeInput }
     | { type: "Sort"; input: LogicalPlan; orders: SortOrder<any>[] }
     | { type: "Limit"; input: LogicalPlan; limit: number }
     | { type: "Distinct"; input: LogicalPlan }
-    | { type: "Union"; inputs: LogicalPlan[]; byName?: boolean; allowMissingColumns?: boolean };
+    | { type: "Union"; inputs: LogicalPlan[]; byName?: boolean; allowMissingColumns?: boolean }
+    | { type: "Describe"; input: LogicalPlan; columns: Expression[] }
+    | { type: "Summary"; input: LogicalPlan; metrics: Expression[]; columns: Expression[] };
 
 export type Expression =
     | { type: "Column"; name: string }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {col, isNotNull, isNull, when} from "./engine/column";
         .option("delimiter", "\t")
         .option("header", "true")
         .csv("/data/purchases.tsv");
-    await people
+/*    await people
         .join(purchases, col("id").eq(col("user_id")))
         .select("name", "product", "amount")
         .filter(col("amount").gt(100))
@@ -139,5 +139,11 @@ import {col, isNotNull, isNull, when} from "./engine/column";
         .avro()
         .option("compression", "snappy")  // ejemplo de opción específica
         .mode("append")
-        .save("/data/dest/purchases_avro");
+        .save("/data/dest/purchases_avro");*/
+/*    await people
+        .describe(["id","name","age","country","year"])
+        .show();
+    await people
+        .summary(["count", "min", "50%", "75%", "max"], ["age"])
+        .show();*/
 })();

--- a/src/read/readDataFrameInterpreter.ts
+++ b/src/read/readDataFrameInterpreter.ts
@@ -46,16 +46,16 @@ export const SparkExprAlg: ExprAlg<Expression> = {
 };
 
 export const SparkDFAlg: DFAlg<LogicalPlan, Expression, GroupBy> = {
-    relation: (format, path, options) => ({ type: "Relation", format, path, options }),
+    relation: (format, path, options) => ({type: "Relation", format, path, options}),
 
-    select: (plan, columns) => ({ type: "Project", input: plan, columns }),
+    select: (plan, columns) => ({type: "Project", input: plan, columns}),
 
-    filter: (plan, condition) => ({ type: "Filter", input: plan, condition }),
+    filter: (plan, condition) => ({type: "Filter", input: plan, condition}),
 
     withColumn: (plan, name, column) => ({
         type: "Project",
         input: plan,
-        columns: [{ type: "UnresolvedStar" }, { type: "Alias", input: column, alias: name }],
+        columns: [{type: "UnresolvedStar"}, {type: "Alias", input: column, alias: name}],
     }),
 
     join: (left, right, on, joinType = DEFAULT_JOIN_TYPE) => ({
@@ -66,7 +66,7 @@ export const SparkDFAlg: DFAlg<LogicalPlan, Expression, GroupBy> = {
         joinType: (joinType.toUpperCase() as JoinTypeInput),
     }),
 
-    groupBy: (plan, cols) => ({ type: "GroupBy", input: plan, expressions: cols }),
+    groupBy: (plan, cols) => ({type: "GroupBy", input: plan, expressions: cols}),
 
     agg: (group, aggregations, groupType?: GroupTypeInput) => ({
         type: "Aggregate",
@@ -78,31 +78,29 @@ export const SparkDFAlg: DFAlg<LogicalPlan, Expression, GroupBy> = {
     orderBy: (plan, orders: SortOrder<Expression>[]) => ({
         type: "Sort",
         input: plan,
-        orders: orders.map(o =>
-            o.expr.type === "SortKey"
-                ? { expr: o.expr.input, direction: o.expr.direction, nulls: o.expr.nulls }
-                : { expr: o.expr, direction: "asc" as const }
+        orders: orders.map(o => o.expr.type === "SortKey"
+            ? {expr: o.expr.input, direction: o.expr.direction, nulls: o.expr.nulls}
+            : {expr: o.expr, direction: "asc" as const}
         ),
     }),
 
     sort: (plan, orders) => ({
         type: "Sort",
         input: plan,
-        orders: orders.map(o =>
-            o.expr.type === "SortKey"
-                ? { expr: o.expr.input, direction: o.expr.direction, nulls: o.expr.nulls }
-                : { expr: o.expr, direction: "asc" as const }
+        orders: orders.map(o => o.expr.type === "SortKey"
+            ? {expr: o.expr.input, direction: o.expr.direction, nulls: o.expr.nulls}
+            : {expr: o.expr, direction: "asc" as const}
         ),
     }),
 
-    limit: (plan, n) => ({ type: "Limit", input: plan, limit: n }),
+    limit: (plan, n) => ({type: "Limit", input: plan, limit: n}),
 
-    distinct: (plan) => ({ type: "Distinct", input: plan }),
+    distinct: (plan) => ({type: "Distinct", input: plan}),
 
     dropDuplicates: (plan, cols) => {
-        if (!cols || cols.length === 0) return { type: "Distinct", input: plan };
-        const gb: GroupBy = { type: "GroupBy", input: plan, expressions: cols };
-        return { type: "Aggregate", input: gb, aggregations: {} };
+        if (!cols || cols.length === 0) return {type: "Distinct", input: plan};
+        const gb: GroupBy = {type: "GroupBy", input: plan, expressions: cols};
+        return {type: "Aggregate", input: gb, aggregations: {}};
     },
 
     union: (left, right, opts) => ({
@@ -116,8 +114,8 @@ export const SparkDFAlg: DFAlg<LogicalPlan, Expression, GroupBy> = {
         type: "Project",
         input: plan,
         columns: [
-            { type: "UnresolvedStar" },
-            { type: "Alias", input: { type: "Column", name: oldName }, alias: newName }
+            {type: "UnresolvedStar"},
+            {type: "Alias", input: {type: "Column", name: oldName}, alias: newName}
         ],
     }),
 
@@ -126,8 +124,21 @@ export const SparkDFAlg: DFAlg<LogicalPlan, Expression, GroupBy> = {
         input: plan,
         columns: Object.entries(mapping).map(([from, to]) => ({
             type: "Alias",
-            input: { type: "Column", name: from },
+            input: {type: "Column", name: from},
             alias: to,
         })),
+    }),
+
+    describe: (plan, columns) => ({
+        type: "Describe",
+        input: plan,
+        columns,
+    }),
+
+    summary: (plan, metrics, columns) => ({
+        type: "Summary",
+        input: plan,
+        metrics,
+        columns,
     }),
 };

--- a/src/read/readDataframe.ts
+++ b/src/read/readDataframe.ts
@@ -82,6 +82,10 @@ export interface DFAlg<R, E, G = unknown> {
     withColumnRenamed(plan: R, oldName: string, newName: string): R;
 
     withColumnsRenamed(plan: R, mapping: Record<string, string>): R;
+
+    describe(plan: R, columns: E[]): R;
+
+    summary(plan: R, metrics: E[], columns: E[]): R;
 }
 
 export interface DFExec<R> {

--- a/test/examples.e2e.test.ts
+++ b/test/examples.e2e.test.ts
@@ -1,5 +1,5 @@
 // test/examples.e2e.test.ts
-import { describe, it, expect, beforeAll } from 'vitest';
+import {describe, it, expect, beforeAll} from 'vitest';
 
 let spark: any;
 let col: any, isNull: any, isNotNull: any, when: any;
@@ -9,11 +9,11 @@ beforeAll(async () => {
     process.env.SPARK_CONNECT_URL ??= 'sc://localhost:15002';
 
     try {
-        ({ spark } = await import('../src/client/session'));
-        ({ col, isNull, isNotNull, when } = await import('../src/engine/column'));
+        ({spark} = await import('../src/client/session'));
+        ({col, isNull, isNotNull, when} = await import('../src/engine/column'));
     } catch {
-        ({ spark } = await import('../dist/client/session.js'));
-        ({ col, isNull, isNotNull, when } = await import('../dist/engine/column.js'));
+        ({spark} = await import('../dist/client/session.js'));
+        ({col, isNull, isNotNull, when} = await import('../dist/engine/column.js'));
     }
 });
 
@@ -33,7 +33,7 @@ describe('examples (E2E)', () => {
             .select('name', 'product', 'amount')
             .filter(col('amount').gt(100))
             .groupBy('name')
-            .agg({ total_spent: 'sum(amount)', items_purchased: 'count(product)' })
+            .agg({total_spent: 'sum(amount)', items_purchased: 'count(product)'})
             .show();
         expect(true).toBe(true);
     }, 90_000);
@@ -49,7 +49,7 @@ describe('examples (E2E)', () => {
     it('groupBy + agg + orderBy + limit', async () => {
         await purchases()
             .groupBy('user_id')
-            .agg({ total_spent: 'sum(amount)' })
+            .agg({total_spent: 'sum(amount)'})
             .orderBy(col('total_spent').descNullsLast())
             .limit(10)
             .show();
@@ -162,7 +162,7 @@ describe('examples (E2E)', () => {
         const pu = purchases();
         const topSpenders = pu
             .groupBy('user_id')
-            .agg({ total_spent: 'sum(amount)' })
+            .agg({total_spent: 'sum(amount)'})
             .orderBy(col('total_spent').descNullsLast());
 
         await topSpenders.write.parquet().mode('overwrite').save('/data/dest/top_spenders');
@@ -175,5 +175,19 @@ describe('examples (E2E)', () => {
         await pu.write.avro().option('compression', 'snappy').mode('append')
             .save('/data/dest/purchases_avro');
         expect(true).toBe(true);
+    }, 90_000);
+    it('describe: id,name,age,country,year', async () => {
+        const df = people();
+        await df
+            .describe(["id", "name", "age", "country", "year"])
+            .show();
+        expect(true).toBe(true);
+    }, 90_000);
+    it('summary: count/min/50%/75%/max sobre age', async () => {
+            const df = people();
+            await df
+                .summary(["count", "min", "50%", "75%", "max"], ["age"])
+                .show();
+            expect(true).toBe(true);
     }, 90_000);
 });


### PR DESCRIPTION
…. Se agregan combinadores tagless-final sobre Spark Connect sin extensiones. Un solo Aggregate global + Projects y UNION ALL. Guard numérico con WHEN/ELSE para evitar CAST_INVALID_INPUT. Soporte de percentiles en summary. Proyección temprana de columnas. Ejemplos y tests e2e añadidos.